### PR TITLE
Feature 7

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,6 +76,7 @@ services:
             # The default system and admin users always use the default authentication method (password)
             - BOCA_SYSTEM_USER=system
             - BOCA_ADMIN_USER=aryelle.siqueira
+            - BOCA_FAKE_TEAM_USER=teamuser
             # specifies the authentication method to use. The possible choices
             # are summarized here:
             #  - password: require the user to supply a password

--- a/src/flog.php
+++ b/src/flog.php
@@ -133,9 +133,11 @@ function DBLogInContest($name,$pass,$contest,$msg=true) {
 	}
 	$a = DBUserInfo($b["contestnumber"], $b["contestlocalsite"],$a['usernumber'],null,false);
 
+	$fakeUser = getenv("BOCA_FAKE_TEAM_USER");
+
 	$a["authmethod"] = getenv("BOCA_AUTH_METHOD") ? getenv("BOCA_AUTH_METHOD") : "password";
 
-	if ($a["authmethod"] != "password" && ($name == "system" || $name == "admin")) {
+	if ($a["authmethod"] != "password" && ($name == "system" || $name == "admin" || ($fakeUser && $name == $fakeUser))) {
 		$a["authmethod"] = "password";
 		$p = $a["userpassword"];
 		$pass = myhash($pass);


### PR DESCRIPTION
Closes #7 

When set, `BOCA_FAKE_TEAM_USER` defines a user (type=team) that can (only) log in using default authentication method (password), regardless of the global method. Useful for testing purposes 